### PR TITLE
setup.py: Make this installable as a module.

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -1,0 +1,10 @@
+from setuptools import setup
+
+setup(name='gmail_oauth2_tools',
+      version='0.1',
+      description='Gmail OAuth2 tools from Google',
+      url='http://github.com/google/gmail-oauth2-tools/',
+      author='Gmail',
+      author_email='google-mail-oauth2-tools@googlegroups.com',
+      license='Apache License 2.0',
+      zip_safe=False)


### PR DESCRIPTION
Provide a simple `setup.py` and empty `__init__.py` to go with it so that you can

```
pip install -e git+https://github.com/google/gmail-oauth2-tools.git#egg=gmail_oauth2_tools&subdirectory=python
```

(Requires pip >= 1.5; see also http://stackoverflow.com/a/26174655/874188)
