### PR TITLE
Don't limit to email with @gmail.com

### DIFF
--- a/go/sendgmail/main.go
+++ b/go/sendgmail/main.go
@@ -30,7 +30,6 @@ import (
 	"log"
 	"net/smtp"
 	"os"
-	"strings"
 
 	"golang.org/x/oauth2"
 	googleOAuth2 "golang.org/x/oauth2/google"
@@ -52,9 +51,6 @@ func init() {
 
 func main() {
 	flag.Parse()
-	if atDomain := "@gmail.com"; !strings.HasSuffix(sender, atDomain) {
-		log.Fatalf("-sender must specify an %v email address.", atDomain)
-	}
 	config := getConfig()
 	tokenPath := fmt.Sprintf("%v/.sendgmail.%v.json", os.Getenv("HOME"), sender)
 	if setUp {


### PR DESCRIPTION
I have custom domains that I manage via GSuite but this restriction on the login having to end with @gmail.com prevented me from using them with git send-email.