### PR TITLE
Fix shebang to explicitly point to python2

### DIFF
--- a/python/oauth2.py
+++ b/python/oauth2.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 #
 # Copyright 2012 Google Inc.
 #


### PR DESCRIPTION
Recent gLinux workstations have removed /usr/bin/python in favor of the
more explicit /usr/bin/python2 and /usr/bin/python3.

Use the former to show that we require python2.