### PR TITLE
sendgmail: remove gmail domain check

### DIFF
--- a/go/sendgmail/main.go
+++ b/go/sendgmail/main.go
@@ -30,7 +30,6 @@ import (
 	"log"
 	"net/smtp"
 	"os"
-	"strings"
 
 	"golang.org/x/oauth2"
 	googleOAuth2 "golang.org/x/oauth2/google"
@@ -52,9 +51,6 @@ func init() {
 
 func main() {
 	flag.Parse()
-	if atDomain := "@gmail.com"; !strings.HasSuffix(sender, atDomain) {
-		log.Fatalf("-sender must specify an %v email address.", atDomain)
-	}
 	config := getConfig()
 	tokenPath := fmt.Sprintf("%v/.sendgmail.%v.json", os.Getenv("HOME"), sender)
 	if setUp {


### PR DESCRIPTION
This program works correctly with Google Workspace accounts as well. So
simply remove the check to ensure a gmail account is being used. This
does mean folks from other providers will not be provided with an
immediate error message, but the risk of confusion seems low considering
the name of the repo is gmail-oauth2-tools.