### PR TITLE
Replace https://oauth2.dance with github pages.

### DIFF
--- a/go/sendgmail/README.md
+++ b/go/sendgmail/README.md
@@ -22,8 +22,9 @@ send-email`.
     *   Follow the steps in the **Authorize credentials for a desktop
         application** section. However, set the application type to *Web
         application* (i.e. instead of *Desktop app*) and then add
-        `https://oauth2.dance/` as an authorised redirect URI. This is necessary
-        for seeing the authorisation code on a page in your browser.
+        `https://google.github.io/gmail-oauth2-tools/html/oauth2.dance.html`
+        as an authorised redirect URI. This is necessary for seeing the
+        authorisation code on a page in your browser.
 
     *   When you download the credentials as JSON, create the
         `${XDG_CONFIG_HOME:-${HOME}/.config}/sendgmail` directory with file mode

--- a/html/oauth2.dance.html
+++ b/html/oauth2.dance.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<style>:root { color-scheme: dark light; }</style>
+<title>oauth2.dance</title>
+<h1>oauth2.dance</h1>
+<div id="authCodeDivFailure" style="display: none;">
+  These aren't the droids you're looking for.
+</div>
+<div id="authCodeDivSuccess" style="display: none;">
+  Authorisation Code:
+  <span id="authCodeSpan" style="font-family: monospace; font-weight: bold;"></span>
+  <br>
+  <button id="authCodeButton">Copy To Clipboard</button>
+</div>
+<script>
+  var searchParams = new URLSearchParams(window.location.search);
+  var code = searchParams.get("code");
+  if (code === null) {
+    var div = document.getElementById("authCodeDivFailure");
+    div.style = "";
+  } else {
+    var button = document.getElementById("authCodeButton");
+    button.addEventListener("click", (e) => { navigator.clipboard.writeText(code); });
+    var span = document.getElementById("authCodeSpan");
+    span.textContent = code;
+    var div = document.getElementById("authCodeDivSuccess");
+    div.style = "";
+  }
+</script>

--- a/python/oauth2.py
+++ b/python/oauth2.py
@@ -22,7 +22,8 @@ See https://developers.google.com/identity/protocols/OAuth2 for instructions on
 registering and for documentation of the APIs invoked by this code.
 
 NOTE: The OAuth2 OOB flow isn't a thing anymore. You will need to set the
-application type to "Web application" and then add https://oauth2.dance/ as an
+application type to "Web application" and then add
+https://google.github.io/gmail-oauth2-tools/html/oauth2.dance.html as an
 authorised redirect URI. This is necessary for seeing the authorisation code on
 a page in your browser.
 
@@ -134,7 +135,7 @@ GOOGLE_ACCOUNTS_BASE_URL = 'https://accounts.google.com'
 
 
 # Hardcoded redirect URI.
-REDIRECT_URI = 'https://oauth2.dance/'
+REDIRECT_URI = 'https://google.github.io/gmail-oauth2-tools/html/oauth2.dance.html'
 
 
 def AccountsUrl(command):


### PR DESCRIPTION
https://oauth2.dance hosted some static content that reflected the OAuth2
token back to you.  After some research, it appears that this domain was
personally owned and hosted by @junyer, who sadly passed away last year.
The domain subsequently expired, was recently reregistered by a third
party and is currently not resolving.
    
This is my proposal to fix this: host the required HTML via Github pages
from this repo itself.  In order to work, *you will need to create a
"gh-pages" branch* containing (at least) the oauth2.dance.html file. You
can see this in action at 
https://daztucker.github.io/gmail-oauth2-tools/html/oauth2.dance.html

This will fix issue#77 and issue#82.
